### PR TITLE
Changing to use composite requests

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -179,14 +179,14 @@ type ChildRelationship struct {
 func (forceApi *ForceApi) getApiResources(ctx context.Context) error {
 	uri := fmt.Sprintf(resourcesUri, forceApi.apiVersion)
 
-	return forceApi.Get(ctx, uri, nil, &forceApi.apiResources)
+	return forceApi.requestNonComposite(ctx, "GET", uri, nil, nil, &forceApi.apiResources, false)
 }
 
 func (forceApi *ForceApi) getApiSObjects(ctx context.Context) error {
 	uri := forceApi.apiResources[sObjectsKey]
 
 	list := &SObjectApiResponse{}
-	err := forceApi.Get(ctx, uri, nil, list)
+	err := forceApi.requestNonComposite(ctx, "GET", uri, nil, nil, list, false)
 	if err != nil {
 		return err
 	}

--- a/force/client.go
+++ b/force/client.go
@@ -3,6 +3,8 @@ package force
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -19,6 +21,31 @@ const (
 	contentType  = "application/json"
 	responseType = "application/json"
 )
+
+type CompositeRequest struct {
+	SubRequests []CompositeSubRequest `json:"compositeRequest"`
+}
+
+type CompositeSubRequest struct {
+	Method       string      `json:"method"`
+	Url          string      `json:"url"`
+	ReferencedID string      `json:"referenceId"`
+	HttpHeaders  http.Header `json:"httpHeaders,omitempty"`
+	Body         interface{} `json:"body,omitempty"`
+}
+
+type CompositeResponse struct {
+	Response []Subvalue `json:"compositeResponse"`
+}
+
+// Subvalue is the subresponses to the composite API.  Using the
+// referende id, one will be able to match the response with the request.
+type Subvalue struct {
+	Body           json.RawMessage   `json:"body"`
+	HTTPHeaders    map[string]string `json:"httpHeaders"`
+	HTTPStatusCode int               `json:"httpStatusCode"`
+	ReferenceID    string            `json:"referenceId"`
+}
 
 // Get issues a GET to the specified path with the given params and put the
 // umarshalled (json) result in the third parameter
@@ -50,6 +77,141 @@ func (forceApi *ForceApi) Delete(ctx context.Context, path string, params url.Va
 }
 
 func (forceApi *ForceApi) request(ctx context.Context, method, path string, params url.Values, payload, out interface{}, retry bool) error {
+	// Build Uri
+	var uri bytes.Buffer
+	uri.WriteString(path)
+	if len(params) != 0 {
+		uri.WriteString("?")
+		uri.WriteString(params.Encode())
+	}
+	uriString := uri.String()
+	compSubRequest := CompositeSubRequest{
+		Method:       method,
+		Url:          uriString,
+		ReferencedID: "sf-request",
+	}
+
+	if payload != nil {
+		compSubRequest.Body = payload
+	}
+
+	// Build Request
+	compRequest := CompositeRequest{
+		SubRequests: []CompositeSubRequest{compSubRequest},
+	}
+
+	jsonBytes, err := json.Marshal(compRequest)
+	if err != nil {
+		return fmt.Errorf("Error marshaling encoded payload: %v", err)
+	}
+
+	var sfURI bytes.Buffer
+	sfURI.WriteString(forceApi.InstanceURL)
+	sfURI.WriteString("/services/data/" + forceApi.apiVersion + "/composite")
+
+	req, err := http.NewRequestWithContext(ctx, "POST", sfURI.String(), bytes.NewReader(jsonBytes))
+	if err != nil {
+		return fmt.Errorf("Error creating %v request: %v", method, err)
+	}
+	// Add Headers
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", responseType)
+
+	// Set this for this request only if requested by caller (if this header is set, OwnerId of created case
+	// will be set to the one we are passing in the request; if header not set, OwnerId is overwritten using SF rules)
+	if forceApi.disableForceAutoAssign {
+		fmt.Println("Disabling force auto assign")
+		req.Header.Set("Sforce-Auto-Assign", "False")
+		forceApi.SetDisableForceAutoAssign(false)
+	}
+
+	// Send
+	forceApi.traceRequest(req)
+	span, ctx := tracer.StartSpanFromContext(ctx, "Salesforce API Request", tracer.ResourceName(uriString))
+	span.SetTag("url", path)
+	span.SetTag("params", params)
+	span.SetTag("http_method", method)
+	resp, err := forceApi.client.Do(req)
+	if err != nil {
+		returnErr := fmt.Errorf("Error sending %v request: %v", method, err)
+		span.Finish(tracer.WithError(returnErr))
+		return returnErr
+	}
+	span.Finish()
+	defer resp.Body.Close()
+	forceApi.traceResponse(resp)
+
+	// Sometimes the force API returns no body, we should catch this early
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error reading response bytes: %v", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		// Attempt to parse response as a force.com api error before returning object unmarshal err
+		apiErrors := ApiErrors{}
+		if marshalErr := forcejson.Unmarshal(respBytes, &apiErrors); marshalErr == nil {
+			if apiErrors.Validate() {
+				// Deal with expired salesforce tokens
+				if apiErrors[0].ErrorCode == "INVALID_SESSION_ID" && !retry {
+					forceApi.jwtMutex.Lock()
+					forceApi.client = forceApi.jwtConfig.Client(ctx)
+					forceApi.jwtMutex.Unlock()
+					return forceApi.request(ctx, method, path, params, payload, out, true)
+				}
+				return apiErrors
+			}
+		}
+	}
+
+	forceApi.traceResponseBody(respBytes)
+	compResponse := &CompositeResponse{}
+	err = json.Unmarshal(respBytes, compResponse)
+	if err != nil {
+		return fmt.Errorf("Error unmarshaling compsite response: %v", err)
+	}
+	if len(compResponse.Response) == 0 {
+		return errors.New("sf response is empty")
+	}
+
+	if compResponse.Response[0].HTTPStatusCode >= 300 {
+		// Attempt to parse response as a force.com api error before returning object unmarshal err
+		apiErrors := ApiErrors{}
+		if marshalErr := forcejson.Unmarshal(compResponse.Response[0].Body, &apiErrors); marshalErr == nil {
+			if apiErrors.Validate() {
+				if apiErrors[0].ErrorCode == "NOT_FOUND" {
+					return nil
+				}
+
+				return apiErrors
+			}
+		}
+	}
+
+	// Attempt to parse response into out
+	var objectUnmarshalErr error
+	if out != nil {
+		objectUnmarshalErr = forcejson.Unmarshal(compResponse.Response[0].Body, out)
+		if objectUnmarshalErr == nil {
+			return nil
+		}
+	}
+
+	if objectUnmarshalErr != nil {
+		// Not a force.com api error. Just an unmarshalling error.
+		return fmt.Errorf("Unable to unmarshal response to object: %v", objectUnmarshalErr)
+	}
+
+	// Sometimes no response is expected. For example delete and update. We still have to make sure an error wasn't returned.
+	return nil
+}
+
+func (forceApi *ForceApi) requestNonComposite(ctx context.Context, method, path string, params url.Values, payload, out interface{}, retry bool) error {
 	// Build Uri
 	var uri bytes.Buffer
 	uri.WriteString(forceApi.InstanceURL)


### PR DESCRIPTION
Switching our salesforce api library to always use composite requests https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_subrequest_result.htm.

This will allow GET request urls to not be limited allowing to select the maximum number of records when doing a soql query. Previously if an IN query with 1000s of ids was done sf would throw an error because url was too long. 